### PR TITLE
[FIX] #8 - publish does not allow for JSON format

### DIFF
--- a/src/main/resources/crash/commands/vertx/bus.groovy
+++ b/src/main/resources/crash/commands/vertx/bus.groovy
@@ -68,6 +68,8 @@ public class bus extends VertxCommand {
       @Usage("The address to send to")
       @Argument(name =  "address")
       @Required String address,
+      @Option(names = ["f","format"])
+      Format format,
       @Usage("The message")
       @Argument(name =  "message", unquote = false)
       @Required List<String> parts) {


### PR DESCRIPTION
Fix for #8 

Added -f format specified for publish call.
